### PR TITLE
convertToHTML: prevents markup that treats <br> like an HTML element that should have an opening and closing tag.

### DIFF
--- a/packages/converter/index.js
+++ b/packages/converter/index.js
@@ -48,6 +48,12 @@ const getHTMLString = node => {
     if (node.type.name === "image") {
       strContent = `<p style="text-align: center;">${strContent}<br></p>`;
     }
+    if (node.type.name === "hardBreak") {
+      // This special case prevents strContent from producing
+      // markup that treats <br> like an HTML element that should
+      // have an opening and closing tag.
+      strContent = "<br>";
+    }
   }
   return strContent;
 };


### PR DESCRIPTION
This fixes the bug described here: https://github.com/nib-edit/Nib/issues/86#issuecomment-571274935, but for convenience, I'll copy the relevant portion here: 

------------------------------------------
Hopefully this super reduced case better illustrates the problem I'm running into: https://codesandbox.io/s/nib-reduced-wdzbh. The code for the reduction is: 

```js
import { convertFromHTML, convertToHTML } from "nib-converter";

const a = convertFromHTML("<br>hi!");
console.log(convertToHTML(a.doc));
```

Which outputs: 

```
<h1 ><br ><br></br>hi!</h1>
```

------------------------------------------


With this patch applied, the output is: 

```
<h1 ><br>hi!</h1>
```

